### PR TITLE
Fix error with missed Settings class

### DIFF
--- a/Controller/OperatorStatusController.php
+++ b/Controller/OperatorStatusController.php
@@ -25,6 +25,7 @@
 
 namespace Mibew\Mibew\Plugin\OperatorStatus\Controller;
 
+use Mibew\Settings;
 use Mibew\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
At the moment one can get the error when trying to check group.

`PHP Fatal error:  Class 'Mibew\\Mibew\\Plugin\\OperatorStatus\\Controller\\Settings'`

This PR fixes the issue.